### PR TITLE
15: subtract width of screen cutouts when calculating keyboard width

### DIFF
--- a/java/src/com/android/inputmethod/keyboard/KeyboardSwitcher.java
+++ b/java/src/com/android/inputmethod/keyboard/KeyboardSwitcher.java
@@ -116,7 +116,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         final KeyboardLayoutSet.Builder builder = new KeyboardLayoutSet.Builder(
                 mThemeContext, editorInfo);
         final Resources res = mThemeContext.getResources();
-        final int keyboardWidth = ResourceUtils.getDefaultKeyboardWidth(res);
+        final int keyboardWidth = ResourceUtils.getDefaultKeyboardWidth(res, mThemeContext);
         final int keyboardHeight = ResourceUtils.getKeyboardHeight(res, settingsValues);
         builder.setKeyboardGeometry(keyboardWidth, keyboardHeight);
         builder.setSubtype(mRichImm.getCurrentSubtype());

--- a/java/src/com/android/inputmethod/keyboard/emoji/EmojiLayoutParams.java
+++ b/java/src/com/android/inputmethod/keyboard/emoji/EmojiLayoutParams.java
@@ -16,6 +16,7 @@
 
 package com.android.inputmethod.keyboard.emoji;
 
+import android.content.Context;
 import android.content.res.Resources;
 import androidx.viewpager.widget.ViewPager;
 import android.view.View;
@@ -37,9 +38,9 @@ final class EmojiLayoutParams {
     private final int mBottomPadding;
     private final int mTopPadding;
 
-    public EmojiLayoutParams(final Resources res) {
+    public EmojiLayoutParams(final Resources res, final Context context) {
         final int defaultKeyboardHeight = ResourceUtils.getDefaultKeyboardHeight(res);
-        final int defaultKeyboardWidth = ResourceUtils.getDefaultKeyboardWidth(res);
+        final int defaultKeyboardWidth = ResourceUtils.getDefaultKeyboardWidth(res, context);
         mKeyVerticalGap = (int) res.getFraction(R.fraction.config_key_vertical_gap_holo,
                 defaultKeyboardHeight, defaultKeyboardHeight);
         mBottomPadding = (int) res.getFraction(R.fraction.config_keyboard_bottom_padding_holo,

--- a/java/src/com/android/inputmethod/keyboard/emoji/EmojiPalettesView.java
+++ b/java/src/com/android/inputmethod/keyboard/emoji/EmojiPalettesView.java
@@ -109,9 +109,9 @@ public final class EmojiPalettesView extends LinearLayout implements OnTabChange
         final KeyboardLayoutSet.Builder builder = new KeyboardLayoutSet.Builder(
                 context, null /* editorInfo */);
         final Resources res = context.getResources();
-        mEmojiLayoutParams = new EmojiLayoutParams(res);
+        mEmojiLayoutParams = new EmojiLayoutParams(res, context);
         builder.setSubtype(RichInputMethodSubtype.getEmojiSubtype());
-        builder.setKeyboardGeometry(ResourceUtils.getDefaultKeyboardWidth(res),
+        builder.setKeyboardGeometry(ResourceUtils.getDefaultKeyboardWidth(res, context),
                 mEmojiLayoutParams.mEmojiKeyboardHeight);
         final KeyboardLayoutSet layoutSet = builder.build();
         final TypedArray emojiPalettesViewAttr = context.obtainStyledAttributes(attrs,
@@ -135,9 +135,10 @@ public final class EmojiPalettesView extends LinearLayout implements OnTabChange
     @Override
     protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        final Resources res = getContext().getResources();
+        final Context context = getContext();
+        final Resources res = context.getResources();
         // The main keyboard expands to the entire this {@link KeyboardView}.
-        final int width = ResourceUtils.getDefaultKeyboardWidth(res)
+        final int width = ResourceUtils.getDefaultKeyboardWidth(res, context)
                 + getPaddingLeft() + getPaddingRight();
         final int height = ResourceUtils.getDefaultKeyboardHeight(res)
                 + res.getDimensionPixelSize(R.dimen.config_suggestions_strip_height)

--- a/java/src/com/android/inputmethod/latin/utils/ResourceUtils.java
+++ b/java/src/com/android/inputmethod/latin/utils/ResourceUtils.java
@@ -16,6 +16,7 @@
 
 package com.android.inputmethod.latin.utils;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.Build;
@@ -23,6 +24,8 @@ import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.Display;
+import android.view.DisplayCutout;
 
 import com.android.inputmethod.annotations.UsedForTesting;
 import com.android.inputmethod.latin.R;
@@ -182,9 +185,15 @@ public final class ResourceUtils {
         return matchedAll;
     }
 
-    public static int getDefaultKeyboardWidth(final Resources res) {
+    public static int getDefaultKeyboardWidth(final Resources res, final Context context) {
         final DisplayMetrics dm = res.getDisplayMetrics();
-        return dm.widthPixels;
+        int width = dm.widthPixels;
+        Display display = context.getDisplay();
+        DisplayCutout cutout = display.getCutout();
+        if (cutout != null) {
+            width -= cutout.getSafeInsetLeft() + cutout.getSafeInsetRight();
+        }
+        return width;
     }
 
     public static int getKeyboardHeight(final Resources res, final SettingsValues settingsValues) {


### PR DESCRIPTION
Cutout region width wasn't included in display metrics screen width before Android 15. This difference led to part of the keyboard being rendered off-screen in landscape mode on devices with screen cutout(s).